### PR TITLE
If factory returns a value use as export.

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -94,7 +94,7 @@ var define, requireModule, require, requirejs;
       }
     }
 
-    if (reified.module.exports) {
+    if (module === undefined && reified.module.exports) {
       return (seen[name] = reified.module.exports);
     } else {
       return (seen[name] = module);

--- a/tests/all.js
+++ b/tests/all.js
@@ -207,3 +207,15 @@ test('pass default deps if arguments are expected and deps not passed', function
 
   require('foo');
 });
+
+test('if factory returns a value it is used as export', function() {
+  define('foo', ['require', 'exports', 'module'], function(require, exports, module) {
+    return {
+      bar:'bar'
+    };
+  });
+
+  var foo = require('foo');
+
+  equal(foo.bar, 'bar');
+});


### PR DESCRIPTION
from spec: 'If the factory function returns a value (an object, function, or any value that coerces to true), then that value should be assigned as the exported value for the module.'
