### PR TITLE
fixed problem with RSVP.js using duplicate relative top name

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -113,6 +113,7 @@ var define, requireModule, require, requirejs;
 
       if (part === '..') { parentBase.pop(); }
       else if (part === '.') { continue; }
+      else if (i == 1 && part == name) { continue; }
       else { parentBase.push(part); }
     }
 

--- a/tests/all.js
+++ b/tests/all.js
@@ -219,3 +219,21 @@ test('if factory returns a value it is used as export', function() {
 
   equal(foo.bar, 'bar');
 });
+
+test('relative import/export with duplicate top name', function(){
+  expect(2);
+
+  define('foo', ['./foo/bar'], function(bar) {
+    equal(bar.baz, 'baz');
+
+    return bar.baz;
+  });
+
+  define('bar', [], function() {
+    return {
+      baz: 'baz'
+    };
+  });
+
+  equal(require('foo'), 'baz');
+});


### PR DESCRIPTION
Hi,

I came across a problem with RSVP.js today, when trying to load their amd version with this loader. Apparently, they're duplicating top module name ("rsvp") in the relative dependencies (e.g. "./rsvp/promise"), and loader.js fails to handle that properly. I made a quick fix to get this working, which is in this pull request, but I'm not sure if there's a better way of handling this issue maybe?

Any feedback would be appreciated. Thank you.
