### PR TITLE
Fix crash loading un-named amd modules

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -51,7 +51,9 @@ var define, requireModule, require, requirejs;
 
     try {
       reified = reify(mod.deps, name, seen[name]);
-      module = mod.callback.apply(this, reified.deps);
+      if (mod.callback != null) {
+        module = mod.callback.apply(this, reified.deps);
+      }
       loaded = true;
     } finally {
       if (!loaded) {


### PR DESCRIPTION
I think this patch over v1.0.0 could be interesting. It avoid a crash loading unnamed amd modules.

I know v1.0.0 is outdated but, for now, it is the only stable version.
