### PR TITLE
Fix crash loading amd modules with no dependencies

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -1,10 +1,26 @@
 var define, requireModule, require, requirejs;
 
 (function() {
+
+  var _isArray;
+  if (!Array.isArray) {
+    _isArray = function (x) {
+      return Object.prototype.toString.call(x) === "[object Array]";
+    };
+  } else {
+    _isArray = Array.isArray;
+  }
+  
   var registry = {}, seen = {}, state = {};
   var FAILED = false;
 
   define = function(name, deps, callback) {
+  
+    if (!_isArray(deps)) {
+      callback = deps;
+      deps     =  [];
+    }
+  
     registry[name] = {
       deps: deps,
       callback: callback


### PR DESCRIPTION
loader.js crashes when you requires a amd module with no dependencies defined. I have cherry-picked some code of master branch and I have created this patch for v1.0.0.

This way, we could use stable version with the possibility of loading amd modules with this kind of definition:

```
define ("module-name", function (){});
```
