### PR TITLE
[fixes #25] since most AMD libraries do not support es6 modules default ...

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -105,11 +105,18 @@ var define, requireModule, require, requirejs;
       }
     });
 
+    var obj;
     if (module === undefined && reified.module.exports) {
-      return (seen[name] = reified.module.exports);
+      obj = reified.module.exports;
     } else {
-      return (seen[name] = module);
+      obj = seen[name] = module;
     }
+
+    if (obj !== null && typeof obj === 'object' && obj['default'] === undefined) {
+      obj['default'] = obj;
+    }
+
+    return (seen[name] = obj);
   };
 
   function resolve(child, name) {

--- a/tests/all.js
+++ b/tests/all.js
@@ -219,3 +219,15 @@ test('if factory returns a value it is used as export', function() {
 
   equal(foo.bar, 'bar');
 });
+
+test("if a module has no default property assume its export is default", function() {
+  define('foo', ['require', 'exports', 'module'], function(require, exports, module) {
+    return {
+      bar:'bar'
+    };
+  });
+
+  var foo = require('foo')['default']
+
+  equal(foo.bar, 'bar');
+});


### PR DESCRIPTION
...we should attempt a quick normalization and assume the export or module is also the default.
