### PR TITLE
Update organization name in repository URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-loader.js [![Build Status](https://travis-ci.org/stefanpenner/loader.js.png?branch=master)](https://travis-ci.org/stefanpenner/loader.js)
+loader.js [![Build Status](https://travis-ci.org/ember-cli/loader.js.png?branch=master)](https://travis-ci.org/ember-cli/loader.js)
 =========
 
 Minimal AMD loader mostly stolen from [@wycats](https://github.com/wycats).
@@ -24,4 +24,4 @@ testem
 
 ## License
 
-loader.js is [MIT Licensed](https://github.com/stefanpenner/loader.js/blob/master/LICENSE.md).
+loader.js is [MIT Licensed](https://github.com/ember-cli/loader.js/blob/master/LICENSE.md).

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "loader.js",
   "main": "loader.js",
   "version": "2.1.1",
-  "homepage": "https://github.com/stefanpenner/loader.js",
+  "homepage": "https://github.com/ember-cli/loader.js",
   "authors": [
     "Stefan Penner <stefan.penner@gmail.com>"
   ],

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/stefanpenner/loader.js/issues"
+    "url": "https://github.com/ember-cli/loader.js/issues"
   },
-  "homepage": "https://github.com/stefanpenner/loader.js"
+  "homepage": "https://github.com/ember-cli/loader.js"
 }


### PR DESCRIPTION
This repository was moved to ember-cli.
