### PR TITLE
Failing case that effects ember-test-helpers

### DIFF
--- a/tests/all.js
+++ b/tests/all.js
@@ -144,6 +144,27 @@ test('deep nested relative import/export', function(){
   equal(require('foo/a/b/c'), 'baz');
 });
 
+test('incorrect lookup paths should fail', function(){
+
+  define('foo/isolated-container', [], function() {
+    return 'container';
+  });
+
+
+  define('foo', ['./isolated-container'], function(container) {
+    return {
+      container: container
+    };
+  });
+
+  throws(function() {
+    return require('foo');
+  }, function(err) {
+      return err.message === 'Could not find module: `isolated-container` imported from: foo';
+  });
+
+});
+
 test('top-level relative import/export', function(){
   expect(2);
 


### PR DESCRIPTION
This is an example of a failing case in the loader.  The compiled output of ember-test-helpers looks like the following. https://gist.github.com/chadhietala/14a0ee7ecdb90e697bbc.  Ember-test-helpers creates a non-named AMD build which might resolve this issue.