### PR TITLE
Tweak error message, actually test it

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -91,7 +91,7 @@ var define, requireModule, require, requirejs;
   function requireFrom(name, origin) {
     var mod = registry[name];
     if (!mod) {
-      throw new Error('Could not find module: `' + name + '` imported from: ' + origin);
+      throw new Error('Could not find module `' + name + '` imported from `' + origin + '`');
     }
     return require(name);
   }

--- a/tests/all.js
+++ b/tests/all.js
@@ -160,7 +160,7 @@ test('incorrect lookup paths should fail', function(){
   throws(function() {
     return require('foo');
   }, function(err) {
-      return err.message === 'Could not find module: `isolated-container` imported from: foo';
+      return err.message === 'Could not find module `isolated-container` imported from `foo`';
   });
 
 });
@@ -288,5 +288,5 @@ test("has good error message for missing module", function() {
 
   throws(function() {
     require('foo');
-  },  'Could not find module: `apple` imported from: foo');
+  }, /Could not find module `apple` imported from `foo`/);
 });


### PR DESCRIPTION
Before: ``Could not find module: `isolated-container` imported from: foo'``
After: ``'Could not find module `isolated-container` imported from `foo`'``

Also, you need to use a regular expression for `QUnit.throws` otherwise it assumes it is the test's display message. See http://api.qunitjs.com/throws/.