### PR TITLE
Allow package to be usable via npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "bower": "^1.3.5"
   },
   "scripts": {
-    "test": "testem ci",
-    "postinstall": "bower install"
+    "test": "testem ci"
   },
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
Currently, npm installing via the git url will fail due to the `postinstall` script defined in package.json (bower not found). By removing it, this package is usable with npm. Is this a use case you're concerned with?