### PR TITLE
Add repository to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,5 +20,9 @@
   "bugs": {
     "url": "https://github.com/ember-cli/loader.js/issues"
   },
-  "homepage": "https://github.com/ember-cli/loader.js"
+  "homepage": "https://github.com/ember-cli/loader.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ember-cli/loader.js.git"
+  }
 }


### PR DESCRIPTION
npm complains about loader.js's package.json missing a "repository" all the
time. This will make it happy.