### PR TITLE
Strips loader plugins from module names

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -121,6 +121,7 @@ var define, requireModule, require, requirejs;
   }
 
   function requireFrom(name, origin) {
+    name = stripLoaderPlugins(name);
     var mod = registry[name];
     if (!mod) {
       throw new Error('Could not find module `' + name + '` imported from `' + origin + '`');

--- a/loader.js
+++ b/loader.js
@@ -28,6 +28,20 @@ var define, requireModule, require, requirejs;
     throw new Error("an unsupported module was defined, expected `define(name, deps, module)` instead got: `" + length + "` arguments to define`");
   }
 
+  function stripLoaderPlugins(name) {
+    if (typeof name !== 'string') return name;
+
+    var position = name.indexOf('!');
+    if (position !== -1) { // contains plugin e.g. module.hbs!hbs
+      name = name.substr(0, position);
+
+      // is the an extension still?
+      name = name.substr(0, name.lastIndexOf('.'));
+    }
+
+    return name;
+  }
+
   var defaultDeps = ['require', 'exports', 'module'];
 
   function Module(name, deps, callback, exports) {
@@ -50,6 +64,8 @@ var define, requireModule, require, requirejs;
   }
 
   define = function(name, deps, callback) {
+    name = stripLoaderPlugins(name);
+
     if (arguments.length < 2) {
       unsupportedModule(arguments.length);
     }
@@ -116,6 +132,7 @@ var define, requireModule, require, requirejs;
     throw new Error('Could not find module ' + name);
   }
   requirejs = require = requireModule = function(name) {
+    name = stripLoaderPlugins(name);
     var mod = registry[name];
 
 

--- a/loader.js
+++ b/loader.js
@@ -35,8 +35,14 @@ var define, requireModule, require, requirejs;
     if (position !== -1) { // contains plugin e.g. module.hbs!hbs
       name = name.substr(0, position);
 
-      // is the an extension still?
-      name = name.substr(0, name.lastIndexOf('.'));
+      // is the a file extension still?
+      var indexOfDot = name.lastIndexOf('.');
+
+      // allow 3 characters for extension, ignore . in the 1st and 2nd positions
+      if (indexOfDot !== -1 && indexOfDot !== 0
+        && indexOfDot !== 1 && indexOfDot < name.length - 3) {
+        name = name.substr(0, indexOfDot);
+      }
     }
 
     return name;

--- a/loader.js
+++ b/loader.js
@@ -40,7 +40,7 @@ var define, requireModule, require, requirejs;
 
       // allow 3 characters for extension, ignore . in the 1st and 2nd positions
       if (indexOfDot !== -1 && indexOfDot !== 0
-        && indexOfDot !== 1 && indexOfDot < name.length - 3) {
+        && indexOfDot !== 1 && name.length - indexOfDot <= 4) {
         name = name.substr(0, indexOfDot);
       }
     }

--- a/tests/all.js
+++ b/tests/all.js
@@ -374,6 +374,14 @@ test('strips jspm plugin definitions and works', function() {
     {
       input: 'pluginTest2.hbs!',
       output: 'pluginTest2'
+    },
+    {
+      input: 'pluginTest3.testhbs!',
+      output: 'pluginTest3.testhbs'
+    },
+    {
+      input: 'pluginTest4.ex!ex',
+      output: 'pluginTest4'
     }
   ];
 

--- a/tests/all.js
+++ b/tests/all.js
@@ -364,22 +364,38 @@ test('foo foo/index are the same thing', function() {
   deepEqual(require('foo'), require('foo/index'));
 });
 
-test('strips plugin definitions and works', function() {
-  var pluginTestCalled = 0;
+test('strips jspm plugin definitions and works', function() {
 
-  define('pluginTest.hbs!hbs', [], function() {
-    pluginTestCalled++;
-  })
+  var pluginPatterns = [
+    {
+      input: 'pluginTest1.hbs!hbs',
+      output: 'pluginTest1'
+    },
+    {
+      input: 'pluginTest2.hbs!',
+      output: 'pluginTest2'
+    }
+  ];
 
-  var pluginTest = require('pluginTest.hbs!hbs');
-  equal(pluginTest, undefined);
-  equal(pluginTestCalled, 1);
-  deepEqual(keys(requirejs.entries), ['pluginTest']);
+  var outputs = pluginPatterns.map(function(item) {
+    return item.output;
+  });
 
-  var pluginTestAgain = require('pluginTest.hbs!hbs');
-  equal(pluginTestAgain, undefined);
-  equal(pluginTestCalled, 1);
+  pluginPatterns.forEach(function(pattern) {
 
-  deepEqual(keys(requirejs.entries), ['pluginTest']);
+    var pluginTestCalled = 0;
+
+    define(pattern.input, [], function() {
+      pluginTestCalled++;
+    })
+
+    var pluginTest = require(pattern.input);
+    equal(pluginTest, undefined);
+    equal(pluginTestCalled, 1);
+
+  });
+
+  deepEqual(keys(requirejs.entries), outputs);
+
 });
 

--- a/tests/all.js
+++ b/tests/all.js
@@ -363,3 +363,23 @@ test('foo foo/index are the same thing', function() {
 
   deepEqual(require('foo'), require('foo/index'));
 });
+
+test('strips plugin definitions and works', function() {
+  var pluginTestCalled = 0;
+
+  define('pluginTest.hbs!hbs', [], function() {
+    pluginTestCalled++;
+  })
+
+  var pluginTest = require('pluginTest.hbs!hbs');
+  equal(pluginTest, undefined);
+  equal(pluginTestCalled, 1);
+  deepEqual(keys(requirejs.entries), ['pluginTest']);
+
+  var pluginTestAgain = require('pluginTest.hbs!hbs');
+  equal(pluginTestAgain, undefined);
+  equal(pluginTestCalled, 1);
+
+  deepEqual(keys(requirejs.entries), ['pluginTest']);
+});
+


### PR DESCRIPTION
This is related to this issue that I raised in ember-cli https://github.com/ember-cli/ember-cli/issues/3902

SystemJS, AMD and others usually support plugins for dynamic compilation of imported non-js modules (http://requirejs.org/docs/plugins.html, https://github.com/jspm/jspm-cli/wiki/Plugins). In order to re-use modules written to work with these loaders in ember-cli, one needs either the plugin support (see the issue) or at least that the ember-cli loader ignores plugins so that ember-cli's asset pipeline has a chance to fix the issue. In particular, the second option will work for templates imported with a plugin (e.g. `import tmpl from 'my-tmpl.hbs!'`) since in ember-cli templates are compiled and made available as normal js modules, removal of .hbs! part by the loader will make the compiled template available to the code without changing the source code and without the plugin support.

This pull requests addresses the plugin syntax used by SystemJS which may be the same for other loaders.