### PR TITLE
Fallback to Node.js "require()" if available in context

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -123,8 +123,18 @@ var define, requireModule, require, requirejs;
     if (mod && mod.callback instanceof Alias) {
       mod = registry[mod.callback.name];
     }
-
-    if (!mod) { missingModule(name); }
+    
+    else if(!mod && global && global.require) {
+      try
+      {
+        return global.require(name);
+      }
+      catch (e) { 
+        missingModule(name);
+      }
+    }
+    
+    else if (!mod) { missingModule(name); }
 
     if (mod.state !== FAILED &&
         seen.hasOwnProperty(name)) {


### PR DESCRIPTION
Allow execution of ember-cli apps in node.js contexts such as nw.js without overwriting/disabling the node.js internal 'require' function.