### PR TITLE
[ENHANCEMENT] Throws a warning if an .js or .hbs extension is in an import moduleName

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -108,9 +108,26 @@ var define, requireModule, require, requirejs;
   function requireFrom(name, origin) {
     var mod = registry[name];
     if (!mod) {
-      throw new Error('Could not find module `' + name + '` imported from `' + origin + '`');
+      missingRequireFromModule(name, origin);
     }
     return require(name);
+  }
+
+  function hasExtension(name, origin) {
+    var extension = name.indexOf('.js') > 0 ? 'js' : false;
+    var moduleName = name.split('.')[0];
+    if (name.indexOf('.hbs') > 0) {
+      extension = 'hbs';
+    }
+
+    if (extension) {
+      throw new Error('The module import for `' + moduleName + '` contains a `.' + extension + '` file extension in module: `' + origin +'`. ');
+    }
+  }
+  
+  function missingRequireFromModule(name, origin) {
+    hasExtension(name, origin);
+    throw new Error('Could not find module `' + name + '` imported from `' + origin + '`');
   }
 
   function missingModule(name) {

--- a/tests/all.js
+++ b/tests/all.js
@@ -318,6 +318,29 @@ test('throws when accessing parent module of root', function() {
   }, /Cannot access parent module of root/);
 });
 
+test('throws if a .js or .hbs file extension is in the module name', function() {
+  expect(2);
+
+  define('bar', function() {
+    return function(){};
+  });
+  define('foo', ['bar.js'], function(bar) {
+    return bar;
+  });
+  define('baz', ['bar.hbs'], function(bar) {
+    return bar;
+  });
+
+  throws(function() {
+    require('foo');
+  }, /The module import for `bar` contains a `.js` file extension in module: `foo`./);
+
+  throws(function() {
+    require('baz');
+  }, /The module import for `bar` contains a `.hbs` file extension in module: `baz`./);
+
+});
+
 test("relative CJS esq require", function() {
   define('foo/a', ['require'], function(require) {
     return require('./b');


### PR DESCRIPTION
As the compiled dist from ember-cli will never contain the file extension in the import path, we should throw an error if the path contains a `.hbs` or `.js` extension.

```
// module `foo.js`
import Bar from 'bar.js';
```

Will now throw a warning:

```
Error: The module import for `bar` contains a `.js` file extension in module: `foo`.
```

This should help new (and forgetful) users troubleshoot accidental imports with extensions in the moduleName.
