### PR TITLE
Refactor

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -142,7 +142,7 @@ var define, requireModule, require, requirejs;
   function findModule(name, referrer) {
     var mod = registry[name];
 
-    if (mod && mod.callback instanceof Alias) {
+    while (mod && mod.callback instanceof Alias) {
       name = mod.callback.name;
       mod = registry[name];
     }

--- a/tests/all.js
+++ b/tests/all.js
@@ -519,3 +519,26 @@ test('alias chain (long)', function() {
 
   equal(require('bozo'), 'I AM BAR');
 });
+
+test('alias chains are lazy', function() {
+  define('bar', [], function(bar) {
+    return 'I AM BAR';
+  });
+
+  define('bar2', [], function(bar) {
+    return 'I AM BAR2';
+  });
+
+  define('quz', define.alias('foo'));
+  define('foo', define.alias('bar'));
+  define('baz', define.alias('quz'));
+
+  define('bozo', define.alias('baz'));
+  define('bozo2', define.alias('baz'));
+
+  equal(require('bozo'), 'I AM BAR');
+
+  define('foo', define.alias('bar2'));
+
+  equal(require('bozo'), 'I AM BAR2');
+});

--- a/tests/all.js
+++ b/tests/all.js
@@ -420,6 +420,26 @@ test('/index fallback with ambiguity (alias after)', function() {
   equal(require('bar'), 'I AM bar with: I AM foo/index');
 });
 
+test('/index fallback with ambiguity (alias after all defines but before require)', function() {
+  define('foo', [], function() {
+    return 'I AM foo';
+  });
+
+  define('foo/index', [], function() {
+    return 'I AM foo/index';
+  });
+
+  define('bar', ['foo'], function(foo) {
+    return 'I AM bar with: ' + foo;
+  });
+
+  define('foo', define.alias('foo/index'));
+
+  equal(require('foo'), 'I AM foo/index');
+  equal(require('foo/index'), 'I AM foo/index');
+  equal(require('bar'), 'I AM bar with: I AM foo/index');
+});
+
 test('alias entries share same module instance', function() {
   var count = 0;
   define('foo', define.alias('foo/index'));

--- a/tests/all.js
+++ b/tests/all.js
@@ -542,3 +542,25 @@ test('alias chains are lazy', function() {
 
   equal(require('bozo'), 'I AM BAR2');
 });
+
+test('alias chains propogate unsee', function() {
+  var counter = 0;
+
+  define('bar', [], function(bar) {
+    counter++;
+    return 'I AM BAR';
+  });
+
+  define('a', define.alias('bar'));
+  define('b', define.alias('a'));
+
+  equal(counter, 0);
+  equal(require('b'), 'I AM BAR');
+  equal(counter, 1);
+  equal(require('b'), 'I AM BAR');
+  equal(counter, 1);
+  require.unsee('b');
+  equal(counter, 1);
+  equal(require('b'), 'I AM BAR');
+  equal(counter, 2);
+});

--- a/tests/all.js
+++ b/tests/all.js
@@ -481,3 +481,41 @@ test('/index fallback + unsee', function() {
 
   equal(count, 3);
 });
+
+test('alias with target \w deps', function() {
+  define('foo', ['bar'], function(bar) {
+    return bar;
+  });
+
+  define('bar', [], function(bar) {
+    return 'I AM BAR';
+  });
+
+  define('quz', define.alias('foo'));
+
+  equal(require('quz'), 'I AM BAR');
+});
+
+test('alias chain (simple)', function() {
+  define('bar', [], function(bar) {
+    return 'I AM BAR';
+  });
+
+  define('quz', define.alias('foo'));
+  define('foo', define.alias('bar'));
+
+  equal(require('quz'), 'I AM BAR');
+});
+
+test('alias chain (long)', function() {
+  define('bar', [], function(bar) {
+    return 'I AM BAR';
+  });
+
+  define('quz', define.alias('foo'));
+  define('foo', define.alias('bar'));
+  define('baz', define.alias('quz'));
+  define('bozo', define.alias('baz'));
+
+  equal(require('bozo'), 'I AM BAR');
+});

--- a/tests/all.js
+++ b/tests/all.js
@@ -564,3 +564,20 @@ test('alias chains propogate unsee', function() {
   equal(require('b'), 'I AM BAR');
   equal(counter, 2);
 });
+
+test('alias chaining with relative deps works', function() {
+  define('foo/baz', [], function() {
+    return 'I AM baz';
+  });
+
+  define('foo/index', ['./baz'], function(baz) {
+    return 'I AM foo/index: ' + baz;
+  });
+
+  define('foo', define.alias('foo/index'));
+  define('bar', define.alias('foo'));
+
+  equal(require('foo'), 'I AM foo/index: I AM baz');
+  equal(require('foo/index'), 'I AM foo/index: I AM baz');
+  equal(require('bar'), 'I AM foo/index: I AM baz');
+});


### PR DESCRIPTION
* improve how aliases work
* make unsee work with aliases
* no-longer delete for unsee
* remove concept of seen
* remove need for try/finally
* prevent the internal module from leaking via the `module` dep
* improve missingModule error messages (always include a useful referrer)

Although many changes have occurred, the external observable behavior should be the same (without bugs). This is intended to be the minor release v3.4.0

@rwjblue r?