### PR TITLE
Allow utilities to wrap/morph callbacks before loader finalizes them

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,22 @@ Note: To be able to take advantage of alternate `define` method name, you will a
 build tooling generates using the alternate.  An example of this is done in the [emberjs-build](https://github.com/emberjs/emberjs-build)
 project in the [babel-enifed-module-formatter plugin](https://github.com/emberjs/emberjs-build/blob/v0.4.2/lib/utils/babel-enifed-module-formatter.js).
 
+## wrapModules
+
+It is possible to hook loader to augment or transform the loaded code.  `wrapModules` is an optional method on the loader that is called as each module is originally loaded.  `wrapModules` must be a function of the form `wrapModules(name, callback)`. The `callback` is the original AMD callback.  The return value of `wrapModules` is then used in subsequent requests for `name`
+
+This functionality is useful for instrumenting code, for instance in code coverage libraries.  
+
+```
+loader.wrapModules = function(name, callback) {
+            if (shouldTransform(name) {
+                    return myTransformer(name, callback);
+                }
+            }
+            return callback;
+    };
+```
+
 ## Tests
 
 To run the test you'll need to have

--- a/loader.js
+++ b/loader.js
@@ -78,6 +78,9 @@ var global = this;
     if (this.finalized) {
       return this.module.exports;
     } else {
+      if (loader.wrapModules) {
+        this.callback = loader.wrapModules(this.name, this.callback);
+      }
       var result = this.callback.apply(this, reifiedDeps);
       if (!(this.hasExportsAsDep && result === undefined)) {
         this.module.exports = result;

--- a/tests/all.js
+++ b/tests/all.js
@@ -657,3 +657,19 @@ test('alias chaining with relative deps works', function() {
   equal(require('foo/index'), 'I AM foo/index: I AM baz');
   equal(require('bar'), 'I AM foo/index: I AM baz');
 });
+
+test('wrapModules is called when present', function() {
+  var fooCalled = 0;
+  var annotatorCalled = 0;
+  loader.wrapModules = function(name, callback) {
+    annotatorCalled++;
+    return callback;
+  };
+  define('foo', [], function() {
+    fooCalled++;
+  });
+
+  equal(annotatorCalled, 0);
+  require('foo');
+  equal(annotatorCalled, 1);
+});


### PR DESCRIPTION
For discussion

see https://github.com/sglanzer/ember-cli-blanket/issues/103
https://github.com/sglanzer/ember-cli-blanket/issues/102 for background

would also resolve: 
https://github.com/sglanzer/ember-cli-blanket/issues/85