### PR TITLE
Avoid defining a `global` variable at the global level

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -1,7 +1,6 @@
 var loader, define, requireModule, require, requirejs;
-var global = this;
 
-(function() {
+(function(global) {
   'use strict';
 
   // Save off the original values of these globals, so we can restore them if someone asks us to
@@ -215,4 +214,4 @@ var global = this;
     requirejs.entries = requirejs._eak_seen = registry = {};
     seen = {};
   };
-})();
+})(this);


### PR DESCRIPTION
Having `var global = this;` causes issues in environments like NW.js or Electron, where `window.global` is actually a thing. See [this issue](https://github.com/brzpegasus/ember-cli-nwjs/issues/48).

I could, if desired, rename the argument in the IIFE to `context` if we don't want to shadow, but this is the minimum required to make things happy in NW.js/Electron-land.