### PR TITLE
Perf

### DIFF
--- a/lib/loader/loader.js
+++ b/lib/loader/loader.js
@@ -63,6 +63,7 @@ var loader, define, requireModule, require, requirejs;
     this.finalized = false;
     this.hasExportsAsDep = false;
     this.isAlias = alias;
+    this.reified = new Array(deps.length);
   }
 
   Module.prototype.makeDefaultExport = function() {
@@ -100,8 +101,8 @@ var loader, define, requireModule, require, requirejs;
   Module.prototype.reify = function() {
     var deps = this.deps;
     var length = deps.length;
-    var reified = new Array(length);
     var dep;
+    var reified = this.reified;
 
     for (var i = 0, l = length; i < l; i++) {
       dep = deps[i];


### PR DESCRIPTION
By removing the `new Array(length)`, `reify` is no longer an array allocation site ( `ArraySingleArgumentConstructorStub`). More specifically, it is no longer the site of an arbitrary length array allocation site .  Although the same work (from a user-perspective) is happening, we merely moved the alloc to the Module constructor. By grouping it with the `Module` allocation we allow `reify` to further specialize.

It may be that the lack of allocation mitigates the need for pre-alloc tenuring related book keeping. But I’m not entirely sure. Ultimately, allowing `reify` to further specialize provides us a nice boost.

before:

```
Benchmark
  file: ./benchmarks/scenarios/ember.js
  total:  4530ms
  per op:  453ms
```

after:

```
Benchmark
  file: ./benchmarks/scenarios/ember.js
  total:  3690ms
  per op:  355ms
```

Profiling related info to which indicates that the array alloc stub costs have been reduced:

Before:
```js
[JavaScript]:
 11    ticks  total  nonlib   name
 12     190   44.7%   65.5%  LazyCompile: *Module.build /Users/stefanpenner/src/loader.js/lib/loader/loader.js:131:36
 13      42    9.9%   14.5%  Stub: ArraySingleArgumentConstructorStub
 14      23    5.4%    7.9%  Stub: CompareICStub
 15      23    5.4%    7.9%  KeyedLoadIC: A keyed load IC from the snapshot
 16       4    0.9%    1.4%  Stub: StringAddStub_CheckNone_NotTenured
 17       2    0.5%    0.7%  LazyCompile: *Module.makeRequire /Users/stefanpenner/src/loader.js/lib/loader/loader.js:123:42
 18       1    0.2%    0.3%  Stub: BinaryOpICStub
 19       1    0.2%    0.3%  LazyCompile: *define /Users/stefanpenner/src/loader.js/lib/loader/loader.js:138:20
 20       1    0.2%    0.3%  Function: ~<anonymous> /Users/stefanpenner/src/loader.js/benchmarks/run-once.js:1:11
```

after

```
[JavaScript]:
 11    ticks  total  nonlib   name
 12     190   44.7%   65.5%  LazyCompile: *Module.build /Users/stefanpenner/src/loader.js/lib/loader/loader.js:131:36
 13      42    9.9%   14.5%  Stub: ArraySingleArgumentConstructorStub
 14      23    5.4%    7.9%  Stub: CompareICStub
 15      23    5.4%    7.9%  KeyedLoadIC: A keyed load IC from the snapshot
 16       4    0.9%    1.4%  Stub: StringAddStub_CheckNone_NotTenured
 17       2    0.5%    0.7%  LazyCompile: *Module.makeRequire /Users/stefanpenner/src/loader.js/lib/loader/loader.js:123:42
 18       1    0.2%    0.3%  Stub: BinaryOpICStub
 19       1    0.2%    0.3%  LazyCompile: *define /Users/stefanpenner/src/loader.js/lib/loader/loader.js:138:20
 20       1    0.2%    0.3%  Function: ~<anonymous> /Users/stefanpenner/src/loader.js/benchmarks/run-once.js:1:11
```

—

doing some playing, if the array in reify isn’t re-alloc eg. `[]`, it is slightly more costly then pre-alloc as `GrowArrayElementsStub` itself consumes about 20% of time and the totally op time increases from ~450 -> ~550, so clearly this PR which reduces it to 350 hits a good sweet spot.