### PR TITLE
Support `import require from 'require';`

### DIFF
--- a/lib/loader/loader.js
+++ b/lib/loader/loader.js
@@ -119,10 +119,14 @@ var loader, define, requireModule, require, requirejs;
 
   Module.prototype.makeRequire = function() {
     var name = this.name;
-
-    return function(dep) {
+    var r = function(dep) {
       return require(resolve(dep, name));
     };
+    r['default'] = r;
+    r.has = function(dep) {
+      return has(resolve(dep, name));
+    }
+    return r;
   };
 
   Module.prototype.build = function() {
@@ -207,7 +211,12 @@ var loader, define, requireModule, require, requirejs;
     return parentBase.join('/');
   }
 
+  function has(name) {
+    return !!(registry[name] || registry[name + '/index']);
+  }
+
   requirejs.entries = requirejs._eak_seen = registry;
+  requirejs.has = has;
   requirejs.unsee = function(moduleName) {
     findModule(moduleName, '(unsee)').unsee();
   };
@@ -221,7 +230,9 @@ var loader, define, requireModule, require, requirejs;
   define('foo',      function() {});
   define('foo/bar',  [], function() {});
   define('foo/asdf', ['module', 'exports', 'require'], function(module, exports, require) {
-    require('foo/bar');
+    if (require.has('foo/bar')) {
+      require('foo/bar');
+    }
   });
   define('foo/baz',  [], define.alias('foo'));
   define('foo/quz',  define.alias('foo'));

--- a/tests/all.js
+++ b/tests/all.js
@@ -673,3 +673,29 @@ test('wrapModules is called when present', function() {
   require('foo');
   equal(annotatorCalled, 1);
 });
+
+test('import require from "require" works', function () {
+  define('foo/baz', function () {
+    return 'I AM baz';
+  });
+
+  define('foo/index', ['require'], function (require) {
+    return require.default('./baz');
+  });
+
+  equal(require('foo'), 'I AM baz');
+});
+
+test('require has a has method', function () {
+  define('foo/baz/index', function () {
+    return 'I AM baz';
+  });
+
+  define('foo/index', ['require'], function (require) {
+    if (require.has('./baz')) {
+      return require.default('./baz');
+    }
+  });
+
+  equal(require('foo'), 'I AM baz');
+});


### PR DESCRIPTION
This is used in ember.js quite a bit, the alternative would be to use `import * as require from 'require';`

Thoughts?  This didn't seem to have any impact on the benchmarks.