### PR TITLE
Avoid setting `QUnit.module.exports`.

### DIFF
--- a/lib/loader/loader.js
+++ b/lib/loader/loader.js
@@ -244,7 +244,7 @@ var loader, define, requireModule, require, requirejs;
 
   requirejs.clear();
 
-  if (typeof module !== 'undefined') {
+  if (typeof exports === 'object' && typeof module === 'object' && module.exports) {
     module.exports = { require: require, define: define };
   }
 })(this);


### PR DESCRIPTION
Beef up node detection a bit to avoid setting `QUnit.module.exports`.

Before this change, using `loader.js@4.0.3` on a page that had `QUnit` loaded would think it was in Node-land and set `QUnit.module.exports = ...`.