### PR TITLE
Do not reify dependencies everytime the same module is looked up

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,6 +1,6 @@
 ### Running benchmarks
 
-note: these benchmarks run in seperate processes, the idea is to similate
+note: these benchmarks run in seperate processes, the idea is to simulate
 initial load + use, not after the JIT has settled
 
 ```sh

--- a/lib/loader/loader.js
+++ b/lib/loader/loader.js
@@ -98,21 +98,25 @@ var loader, define, requireModule, require, requirejs;
   };
 
   Module.prototype.reify = function() {
-    var deps = this.deps;
-    var dep;
-    var reified = this.reified;
+    if (!this.finalized) {
+      // only reify once when the module is evaluated for the first time.
+      // thereafter, it will reuse the reified values.
+      var deps = this.deps;
+      var dep;
+      var reified = this.reified;
 
-    for (var i = 0; i < deps.length; i++) {
-      dep = deps[i];
-      if (dep === 'exports') {
-        this.hasExportsAsDep = true;
-        reified[i] = this.module.exports;
-      } else if (dep === 'require') {
-        reified[i] = this.makeRequire();
-      } else if (dep === 'module') {
-        reified[i] = this.module;
-      } else {
-        reified[i] = findModule(resolve(dep, this.name), this.name).module.exports;
+      for (var i = 0; i < deps.length; i++) {
+        dep = deps[i];
+        if (dep === 'exports') {
+          this.hasExportsAsDep = true;
+          reified[i] = this.module.exports;
+        } else if (dep === 'require') {
+          reified[i] = this.makeRequire();
+        } else if (dep === 'module') {
+          reified[i] = this.module;
+        } else {
+          reified[i] = findModule(resolve(dep, this.name), this.name).module.exports;
+        }
       }
     }
   };


### PR DESCRIPTION
We ideally only need to reify the dependencies of a module once for the first time it is looked up. Thereafter, we can reuse the store reified values. This PR fixes that. Earlier it was reifiying the dependencies of a module and evaluating the sub tree irrespective of if the dependencies were already resolved.

cc: @chadhietala 