### PR TITLE
Do not put modules in pending queue if they have been finalized

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -4,20 +4,20 @@ note: these benchmarks run in seperate processes, the idea is to similate
 initial load + use, not after the JIT has settled
 
 ```sh
-env NODE_ENV=production node runner.js ./benchmarks/scenarios/<name of scenario>
+env NODE_ENV=production node ./benchmarks/runner.js ./benchmarks/scenarios/<name of scenario>
 ```
 
 If you want to run in a single process, to easily debug or run a profiler the
 `run-once.js` should be considered
 
 ```sh
-env NODE_ENV=production node run-once.js ./benchmarks/scenarios/<name of scenario>
+env NODE_ENV=production node ./benchmarks/run-once.js ./benchmarks/scenarios/<name of scenario>
 ```
 
 Running with the profiler:
 
 ```sh
-env NODE_ENV=production node --prof run-once.js ./benchmarks/scenarios/<name of scenario>
+env NODE_ENV=production node --prof ./benchmarks/run-once.js ./benchmarks/scenarios/<name of scenario>
 
 # to view the output:
 node --prof-process isolate-0x<name of file>

--- a/lib/loader/loader.js
+++ b/lib/loader/loader.js
@@ -35,11 +35,13 @@ var loader, define, requireModule, require, requirejs;
       resolve: 0,
       resolveRelative: 0,
       findModule: 0,
+      pendingQueueLength: 0
     };
     requirejs._stats = stats;
   }
 
   var stats;
+
   resetStats();
 
   loader = {
@@ -81,7 +83,7 @@ var loader, define, requireModule, require, requirejs;
   var defaultDeps = ['require', 'exports', 'module'];
 
   function Module(name, deps, callback, alias) {
-    stats.modules ++;
+    stats.modules++;
     this.id        = uuid++;
     this.name      = name;
     this.deps      = !deps.length && callback.length ? defaultDeps : deps;
@@ -222,9 +224,10 @@ var loader, define, requireModule, require, requirejs;
 
     if (!mod) { missingModule(name, referrer); }
 
-    if (pending) {
+    if (pending && !mod.finalized) {
       mod.findDeps(pending);
       pending.push(mod);
+      stats.pendingQueueLength++;
     }
     return mod;
   }


### PR DESCRIPTION
With the 2 pass approach to finding deps and evaluating them squentially, we are putting modules that have already been evaluated as well. This is not needed since when the module is read from the pending queue, it will return. However, we do not really need to push it in the pending queue and then know if it was finalized.

This is a minor optimization to the pending queue.

For example, consider two circular dependent modules:
```js
define('foo', ['bar', 'exports'], function(bar, __exports__) {
    __exports__.quz = function() {
      return bar.baz;
    };
  });

define('bar', ['foo', 'exports'], function(foo, __exports__) {
    __exports__.baz = function() {
      return foo.quz;
    };
  });

var bar = require('bar');
var foo = require('foo');
```

 Before the changes when the `require('foo')` is executed, the pending queue will end up containing `foo` even though it was reified and finalized during `require('bar')`. Even though it does nothing (ie not executed since finalized is true for that module) when ending up being in the queue, it doesn't seem necessary to add the module in the queue.

With this change, the pending queue will be empty when `require('foo')`. 

Please let me know if you need me to add a tests around the pending queue. It doesn't seem `stats` is capturing length of `pending` queue which I think it should for testing purposes.

cc: @chadhietala @krisselden @stefanpenner 