### PR TITLE
Do not put modules that are already in the pending queue

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -4,20 +4,20 @@ note: these benchmarks run in seperate processes, the idea is to similate
 initial load + use, not after the JIT has settled
 
 ```sh
-env NODE_ENV=production node runner.js ./benchmarks/scenarios/<name of scenario>
+env NODE_ENV=production node ./benchmarks/runner.js ./benchmarks/scenarios/<name of scenario>
 ```
 
 If you want to run in a single process, to easily debug or run a profiler the
 `run-once.js` should be considered
 
 ```sh
-env NODE_ENV=production node run-once.js ./benchmarks/scenarios/<name of scenario>
+env NODE_ENV=production node ./benchmarks/run-once.js ./benchmarks/scenarios/<name of scenario>
 ```
 
 Running with the profiler:
 
 ```sh
-env NODE_ENV=production node --prof run-once.js ./benchmarks/scenarios/<name of scenario>
+env NODE_ENV=production node --prof ./benchmarks/run-once.js ./benchmarks/scenarios/<name of scenario>
 
 # to view the output:
 node --prof-process isolate-0x<name of file>

--- a/lib/loader/loader.js
+++ b/lib/loader/loader.js
@@ -94,6 +94,7 @@ var loader, define, requireModule, require, requirejs;
     this.isAlias = alias;
     this.reified = new Array(deps.length);
     this._foundDeps = false;
+    this.isPending = false;
   }
 
   Module.prototype.makeDefaultExport = function() {
@@ -110,6 +111,7 @@ var loader, define, requireModule, require, requirejs;
     stats.exports++;
 
     this.finalized = true;
+    this.isPending = false;
 
     if (loader.wrapModules) {
       this.callback = loader.wrapModules(this.name, this.callback);
@@ -129,6 +131,7 @@ var loader, define, requireModule, require, requirejs;
   Module.prototype.unsee = function() {
     this.finalized = false;
     this._foundDeps = false;
+    this.isPending = false;
     this.module = { exports: {}};
   };
 
@@ -148,6 +151,7 @@ var loader, define, requireModule, require, requirejs;
 
     stats.findDeps++;
     this._foundDeps = true;
+    this.isPending = true;
 
     var deps = this.deps;
 
@@ -224,7 +228,7 @@ var loader, define, requireModule, require, requirejs;
 
     if (!mod) { missingModule(name, referrer); }
 
-    if (pending && !mod.finalized) {
+    if (pending && !mod.finalized && !mod.isPending) {
       mod.findDeps(pending);
       pending.push(mod);
       stats.pendingQueueLength++;

--- a/lib/loader/loader.js
+++ b/lib/loader/loader.js
@@ -35,11 +35,13 @@ var loader, define, requireModule, require, requirejs;
       resolve: 0,
       resolveRelative: 0,
       findModule: 0,
+      pendingQueueLength: 0
     };
     requirejs._stats = stats;
   }
 
   var stats;
+
   resetStats();
 
   loader = {
@@ -81,7 +83,7 @@ var loader, define, requireModule, require, requirejs;
   var defaultDeps = ['require', 'exports', 'module'];
 
   function Module(name, deps, callback, alias) {
-    stats.modules ++;
+    stats.modules++;
     this.id        = uuid++;
     this.name      = name;
     this.deps      = !deps.length && callback.length ? defaultDeps : deps;
@@ -222,9 +224,10 @@ var loader, define, requireModule, require, requirejs;
 
     if (!mod) { missingModule(name, referrer); }
 
-    if (pending) {
+    if (pending && !mod.finalized) {
       mod.findDeps(pending);
       pending.push(mod);
+      stats.pendingQueueLength++;
     }
     return mod;
   }

--- a/tests/all.js
+++ b/tests/all.js
@@ -437,7 +437,7 @@ test('runtime cycles', function() {
     require: 2,
     resolve: 2,
     resolveRelative: 0,
-    pendingQueueLength: 3
+    pendingQueueLength: 2
   });
 
   ok(foo.quz());
@@ -471,7 +471,7 @@ test('already evaluated modules are not pushed into the queue', function() {
     require: 1,
     resolve: 2,
     resolveRelative: 0,
-    pendingQueueLength: 3
+    pendingQueueLength: 2
   });
 
   var foo = require('foo');
@@ -485,9 +485,37 @@ test('already evaluated modules are not pushed into the queue', function() {
     require: 2,
     resolve: 2,
     resolveRelative: 0,
-    pendingQueueLength: 3
+    pendingQueueLength: 2
   });
 });
+
+test('same pending modules should not be pushed to the queue more than once', function() {
+  define('foo', ['bar', 'exports'], function(bar, __exports__) {
+    __exports__.quz = function() {
+      return bar.baz;
+    };
+  });
+
+  define('bar', ['foo', 'exports'], function(foo, __exports__) {
+    __exports__.baz = function() {
+      return foo.quz;
+    };
+  });
+
+  var bar = require('bar');
+  deepEqual(require._stats, {
+    findDeps: 2,
+    define: 2,
+    exports: 2,
+    findModule: 3,
+    modules: 2,
+    reify: 2,
+    require: 1,
+    resolve: 2,
+    resolveRelative: 0,
+    pendingQueueLength: 2
+  });
+})
 
 test('basic CJS mode', function() {
   define('a/foo', ['require', 'exports', 'module'], function(require, exports, module) {


### PR DESCRIPTION
Follow up of this [PR](https://github.com/ember-cli/loader.js/pull/85)

If a module that has not been evaluated yet is present in the pending queue, we should not put it in the pending queue. This is because we know it will be evaluated earlier than we need it.
    
This PR fixes that.

cc: @chadhietala @stefanpenner @krisselden 