### PR TITLE
Ignore uneeded files on npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,10 @@
     "test": "testem ci && jshint lib tests && jscs lib tests",
     "test:dev": "testem"
   },
+  "files": [
+    "index.js",
+    "lib"
+  ],
   "author": "",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
Adding an .npmignore to this folder to ignore unwanted files on publishing this package. Also it seems .npmignore takes preference over `"files"` field in package.json, therefore I chose to this method.

Tested with `npm pack`. Result was as follows:
```javascript
krahuja-mn1:loader.js krahuja$ npm pack
loader.js-4.0.10.tgz
krahuja-mn1:loader.js krahuja$ tar -tf loader.js-4.0.10.tgz
package/package.json
package/.npmignore
package/README.md
package/index.js
package/LICENSE.md
package/lib/loader/loader.js
```

cc: @stefanpenner 
