### PR TITLE
Prevent loader to add default on frozen objects

### DIFF
--- a/lib/loader/loader.js
+++ b/lib/loader/loader.js
@@ -102,7 +102,7 @@ var loader, define, requireModule, require, requirejs;
     var exports = this.module.exports;
     if (exports !== null &&
         (typeof exports === 'object' || typeof exports === 'function') &&
-          exports['default'] === undefined) {
+          exports['default'] === undefined && !Object.isFrozen(exports)) {
       exports['default'] = exports;
     }
   };


### PR DESCRIPTION
If no default is defined on exports, loader.js will try to add one.
This can cause troubles with some bundles exported from rollupjs.