### PR TITLE
Use dict for registery and seen to avoid filling IC cache

### DIFF
--- a/lib/loader/loader.js
+++ b/lib/loader/loader.js
@@ -3,6 +3,13 @@ var loader, define, requireModule, require, requirejs;
 (function(global) {
   'use strict';
 
+  function dict() {
+    var obj = Object.create(null);
+    obj['__'] = undefined;
+    delete obj['__'];
+    return obj;
+  }
+
   var stats;
 
   // Save off the original values of these globals, so we can restore them if someone asks us to
@@ -71,8 +78,8 @@ var loader, define, requireModule, require, requirejs;
     _isArray = Array.isArray;
   }
 
-  var registry = {};
-  var seen = {};
+  var registry = dict();
+  var seen = dict();
 
   var uuid = 0;
 
@@ -294,8 +301,8 @@ var loader, define, requireModule, require, requirejs;
 
   requirejs.clear = function() {
     resetStats();
-    requirejs.entries = requirejs._eak_seen = registry = {};
-    seen = {};
+    requirejs.entries = requirejs._eak_seen = registry = dict();
+    seen = dict();
   };
 
   // prime


### PR DESCRIPTION
While this does not effect the benchmarks please see convo with @krisselden below:

```
kselden [10:34 AM]  
one thing, the loader is filling our IC cache

[10:34]  
it hits 12 then deopts to dictionary

[10:34]  
we should put it in dictionary straight away

[10:34]  
route-recognizer was worse

[10:34]  
because it was a tree

[10:35]  
so it was putting all these shapes and route names into the IC cache

chietala [10:35 AM]  
I see. Seems like a quick fix
```

Before:

<img width="944" alt="screen shot 2016-12-16 at 10 45 29 am" src="https://cloud.githubusercontent.com/assets/183799/21274384/ce6cfa2e-c37c-11e6-9d43-da73d1db9fbe.png">

After:

<img width="927" alt="screen shot 2016-12-16 at 10 45 59 am" src="https://cloud.githubusercontent.com/assets/183799/21274404/e7855bd2-c37c-11e6-828d-96a07a6acf82.png">
