### PR TITLE
CI: Enable automatic NPM deployment for tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,12 @@ node_js:
 
 install:
   - npm install
+
+deploy:
+  provider: npm
+  email: stefan.penner+ember-cli@gmail.com
+  api_key:
+    secure: XPEVBjA2PvOtQQvjrLoltMr+5eVw35nqX46OD7ACrTrppudeDhKB+iDcAGgYNTCAVNsN6reSkupy5XdOpF93P4J4hK9BZ46RUQ9+INR+reU/LpJdzjVQJqlOcCLdppkbmoJuUUiv6O2nJDOrDqmADbI5NMM08XPprnsGS1Re/2c=
+  on:
+    tags: true
+    repo: ember-cli/loader.js


### PR DESCRIPTION
After merging this you no longer have to `npm publish` manually. TravisCI will test all pushed tags and deploy automatically after all tests passed.

`git owner add ember-cli` is still needed, because I didn't have the NPM owner bit to do it myself.

/cc @nathanhammond @stefanpenner @rwjblue