### PR TITLE
Improve redefinition scenarios

### DIFF
--- a/lib/loader/loader.js
+++ b/lib/loader/loader.js
@@ -217,6 +217,15 @@ var loader, define, requireModule, require, requirejs;
   };
 
   define = function(name, deps, callback) {
+    var module = registry[name];
+
+    // If a module for this name has already been defined and is in any state
+    // other than `new` (meaning it has been or is currently being required),
+    // then we return early to avoid redefinition.
+    if (module && module.state !== 'new') {
+      return;
+    }
+
     var token = heimdall.start('define');
     heimdall.increment(__define);
     if (arguments.length < 2) {

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "testem": "^1.0.0"
   },
   "scripts": {
-    "test": "./build.js && testem ci && jshint lib tests && jscs lib tests",
-    "test:dev": "./build.js && testem",
+    "test": "testem ci && jshint lib tests && jscs lib tests",
+    "test:dev": "testem",
     "prepublish": "./build.js"
   },
   "files": [

--- a/testem.json
+++ b/testem.json
@@ -5,6 +5,7 @@
     "lib/loader/loader.js",
     "tests/all.js"
   ],
+  "before_tests": "./build.js",
   "test_page": "tests/index.html?hidepassed",
   "launch_in_dev": [
     "PhantomJS",


### PR DESCRIPTION
Addressing https://github.com/ember-cli/loader.js/issues/103.

This changes enforces the following behaviors (for which tests are added):
- redefining a module when `new` replaces previous definition
- redefining a module when `pending` should no-op
- redefining a module when `reifying` should no-op
- redefining a module when `reified` should no-op
- redefining a module when `errored` ~~replaces previous definition*~~ should no-op.
- redefining a module when `finalized` should no-op

~~*_The `errored` case is the only one I am unsure of. I think the definition should be replaced because, as with `new`, the module definition itself has never actually executed._~~

TODO:
- [x] Additional tests for other states