### PR TITLE
Check object extensibility before adding default property.

### DIFF
--- a/lib/loader/loader.js
+++ b/lib/loader/loader.js
@@ -123,7 +123,7 @@ var loader, define, requireModule, require, requirejs;
     var exports = this.module.exports;
     if (exports !== null &&
         (typeof exports === 'object' || typeof exports === 'function') &&
-          exports['default'] === undefined && !Object.isFrozen(exports)) {
+          exports['default'] === undefined && Object.isExtensible(exports)) {
       exports['default'] = exports;
     }
   };

--- a/tests/all.js
+++ b/tests/all.js
@@ -736,6 +736,80 @@ test('if a module has no default property assume its export is default (function
   });
 });
 
+test('if a module has no default property assume its export is default (object)', function() {
+  var theObject = {};
+  define('foo', ['require', 'exports', 'module'], function() {
+    return theObject;
+  });
+
+  equal(require('foo')['default'], theObject);
+  equal(require('foo'), theObject);
+
+  var stats = statsForMonitor('loaderjs', tree);
+
+  deepEqual(stats, {
+    findDeps: 1,
+    define: 1,
+    exports: 1,
+    findModule: 2,
+    modules: 1,
+    reify: 1,
+    require: 2,
+    resolve: 0,
+    resolveRelative: 0,
+    pendingQueueLength: 1
+  });
+});
+
+test('does not add default if export is frozen', function() {
+  var theObject = Object.freeze({});
+  define('foo', ['require', 'exports', 'module'], function() {
+    return theObject;
+  });
+
+  ok(!('default' in require('foo')));
+  equal(require('foo'), theObject);
+
+  var stats = statsForMonitor('loaderjs', tree);
+
+  deepEqual(stats, {
+    findDeps: 1,
+    define: 1,
+    exports: 1,
+    findModule: 2,
+    modules: 1,
+    reify: 1,
+    require: 2,
+    resolve: 0,
+    resolveRelative: 0,
+    pendingQueueLength: 1
+  });
+});
+
+test('does not add default if export is sealed', function() {
+  var theObject = Object.seal({ derp: {} });
+  define('foo', ['require', 'exports', 'module'], function() {
+    return theObject;
+  });
+
+  ok(!('default' in require('foo')));
+  equal(require('foo'), theObject);
+
+  var stats = statsForMonitor('loaderjs', tree);
+
+  deepEqual(stats, {
+    findDeps: 1,
+    define: 1,
+    exports: 1,
+    findModule: 2,
+    modules: 1,
+    reify: 1,
+    require: 2,
+    resolve: 0,
+    resolveRelative: 0,
+    pendingQueueLength: 1
+  });
+});
 
 test('has good error message for missing module', function() {
   var theFunction = function theFunction() {};


### PR DESCRIPTION
The checks added previously were checking for `Object.isFrozen`, but that only covers one scenario (`Object.freeze`) and it is still possible to make an object 
non-extensible without freezing it.

This adds tests for frozen objects (previously passing) and a new test for `Object.seal`'ed objects (which was failing prior to this change).