### PR TITLE
Remove `lib/` from published files.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
   "files": [
     "dist",
     "index.js",
-    "utils.js",
-    "lib"
+    "utils.js"
   ],
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
There is no `.npmignore` file excluding these, so `files: []` here is the SOT.
This might help make errors with `bower install` more obvious, as bower tends to attempt to pull from `lib/` and will not have `dist/` available to it.