### PR TITLE
Add target option to define.alias

### DIFF
--- a/lib/loader/loader.js
+++ b/lib/loader/loader.js
@@ -252,7 +252,11 @@ var loader, define, requireModule, require, requirejs;
     this.name = path;
   }
 
-  define.alias = function(path) {
+  define.alias = function(path, target) {
+    if (arguments.length === 2) {
+      return define(target, new Alias(path));
+    }
+
     return new Alias(path);
   };
 
@@ -329,6 +333,7 @@ var loader, define, requireModule, require, requirejs;
   });
   define('foo/baz',  [], define.alias('foo'));
   define('foo/quz',  define.alias('foo'));
+  define.alias('foo', 'foo/qux');
   define('foo/bar',  ['foo', './quz', './baz', './asdf', './bar', '../foo'], function() {});
   define('foo/main', ['foo/bar'], function() {});
 

--- a/tests/all.js
+++ b/tests/all.js
@@ -1180,6 +1180,25 @@ test('alias entries share same module instance', function() {
   });
 });
 
+test('alias with 2 arguments entries share same module instance', function() {
+  var count = 0;
+  define.alias('foo/index', 'bar');
+
+  define('foo/index', [], function() {
+    count++;
+    return {};
+  });
+
+  equal(count, 0);
+  var bar = require('bar');
+  equal(count, 1);
+
+  var fooIndex = require('foo/index');
+  equal(count, 1, 'second require should use existing instance');
+
+  strictEqual(bar, fooIndex);
+});
+
 test('/index fallback + unsee', function() {
   var count = 0;
   define('foo/index', [], function() {


### PR DESCRIPTION
This allows define.alias to be used with args similar to constructing
symlinks which makes it more intuitive and less verbose.

In other words, instead of:

```js
define('bar', define.alias('foo'));
```

You can simply do:

```js
define.alias('foo', 'bar');
```