### PR TITLE
add define.exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,77 @@ loader.noConflict({
 });
 ```
 
+## Extra stuff
+
+### `define.alias('new-name', 'old/path')`
+
+`define.alias` allows creation of a symlink from one module to another, for example:
+
+```js
+define('foo/bar/baz', [], () => 'hi');
+define.alias('foo', 'foo/bar/baz');
+
+require('foo') // => 'hi';
+require('foo') === require('foo/bar/baz');
+```
+
+### `define.exports('foo', {})`
+
+`define.exports` enables a fastpath for non-lazy dependency-less modules, for example:
+
+Rather then:
+
+```js
+define("my-foo-app/templates/application", ["exports"], function (exports) {
+  "use strict";
+
+  Object.defineProperty(exports, "__esModule", {
+    value: true
+  });
+
+  exports.default = Ember.HTMLBars.template({ "id": "VVZNWoRm", "block": "{\"statements\":[[1,[26,[\"welcome-page\"]],false],[0,\"\\n\"],[0,\"\\n\"],[1,[26,[\"outlet\"]],false]],\"locals\":[],\"named\":[],\"yields\":[],\"hasPartials\":false}", "meta": { "moduleName": "my-foo-app/templates/application.hbs" } });
+});
+```
+
+We can author:
+
+```js
+define.exports('my-app/template/apple', { hbs: true, "id": "VVZNWoRm", "block": "{\"statements\":[[1,[26,[\"welcome-page\"]],false],[0,\"\\n\"],[0,\"\\n\"],[1,[26,[\"outlet\"]],false]],\"locals\":[],\"named\":[],\"yields\":[],\"hasPartials\":false}", "meta": { "moduleName": "my-foo-app/templates/application.hbs" }});
+```
+
+benefits:
+
+* less bytes
+* no reification step
+* no need to juggle pre-parse voodoo.
+
+### `require.unsee('foo');
+
+`require.unsee` allows one to unload a given module. *note* The side-affects of that module cannot be unloaded.
+This is quite useful, especially for test suites. Being able to unload run tests, mitigates many common memory leaks:
+
+example:
+
+```js
+define('my-app/tests/foo-test.js', ['qunit'], function(qunit) {
+  let app;
+
+  qunit.module('my module', {
+    beforeEach() {
+      app = new App();
+    }
+
+    // forgot to `null` out app in the afterEach
+  });
+
+  test('my app exists', function(assert) {
+    assert.ok(app);
+  })
+})
+```
+
+---
+
 Note: To be able to take advantage of alternate `define` method name, you will also need to ensure that your
 build tooling generates using the alternate.  An example of this is done in the [emberjs-build](https://github.com/emberjs/emberjs-build)
 project in the [babel-enifed-module-formatter plugin](https://github.com/emberjs/emberjs-build/blob/v0.4.2/lib/utils/babel-enifed-module-formatter.js).

--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ benefits:
 * no reification step
 * no need to juggle pre-parse voodoo.
 
-### `require.unsee('foo');
+### `require.unsee('foo');`
 
-`require.unsee` allows one to unload a given module. *note* The side-affects of that module cannot be unloaded.
+`require.unsee` allows one to unload a given module. *note* The side-effects of that module cannot be unloaded.
 This is quite useful, especially for test suites. Being able to unload run tests, mitigates many common memory leaks:
 
 example:

--- a/benchmarks/scenarios/define-many-exports.js
+++ b/benchmarks/scenarios/define-many-exports.js
@@ -1,0 +1,16 @@
+this.heimdall = global.heimdall = require('heimdalljs');
+var loader = require('../loader');
+var measure = require('../handler').measure;
+
+module.exports = function() {
+  return measure(function() {
+    loader.define('foo' + -1, function() {});
+    for (var i = 0; i < 1000; i++) {
+      loader.define.exports('foo' + i, {hbs: true, "id": "VVZNWoRm", "block": "{\"statements\":[[1,[26,[\"welcome-page\"]],false],[0,\"\\n\"],[0,\"\\n\"],[1,[26,[\"outlet\"]],false]],\"locals\":[],\"named\":[],\"yields\":[],\"hasPartials\":false}", "meta": { "moduleName": "my-foo-app/templates/application.hbs" }});
+    }
+
+    for (var i = 0; i < 1000; i++) {
+      loader.require('foo' + i);
+    }
+  });
+};

--- a/benchmarks/scenarios/define-many.js
+++ b/benchmarks/scenarios/define-many.js
@@ -1,0 +1,32 @@
+this.heimdall = global.heimdall = require('heimdalljs');
+var loader = require('../loader');
+var measure = require('../handler').measure;
+
+module.exports = function() {
+  return measure(function() {
+    var Ember = {
+      HTMLBars: {
+        template: function(stuff) {
+
+        }
+      }
+    };
+
+    loader.define('foo' + -1, function() {});
+    for (var i = 0; i < 1000; i++) {
+      loader.define('foo' + i, ['exports'], function() {
+        "use strict";
+
+        Object.defineProperty(exports, "__esModule", {
+          value: true
+        });
+
+        exports.default = Ember.HTMLBars.template({ "id": "VVZNWoRm", "block": "{\"statements\":[[1,[26,[\"welcome-page\"]],false],[0,\"\\n\"],[0,\"\\n\"],[1,[26,[\"outlet\"]],false]],\"locals\":[],\"named\":[],\"yields\":[],\"hasPartials\":false}", "meta": { "moduleName": "my-foo-app/templates/application.hbs" } });
+      });
+    }
+
+    for (var i = 0; i < 1000; i++) {
+      loader.require('foo' + i);
+    }
+  });
+};

--- a/lib/loader/loader.js
+++ b/lib/loader/loader.js
@@ -245,6 +245,26 @@ var loader, define, requireModule, require, requirejs;
     heimdall.stop(token);
   };
 
+  define.exports = function(name, defaultExport) {
+    var module = registry[name];
+
+    // If a module for this name has already been defined and is in any state
+    // other than `new` (meaning it has been or is currently being required),
+    // then we return early to avoid redefinition.
+    if (module && module.state !== 'new') {
+      return;
+    }
+
+    module = new Module(name, [], noop, null);
+    module.module.exports = defaultExport;
+    module.state = 'finalized';
+    registry[name] = module;
+
+    return module;
+
+  };
+
+  function noop() { }
   // we don't support all of AMD
   // define.amd = {};
 
@@ -336,7 +356,9 @@ var loader, define, requireModule, require, requirejs;
   define.alias('foo', 'foo/qux');
   define('foo/bar',  ['foo', './quz', './baz', './asdf', './bar', '../foo'], function() {});
   define('foo/main', ['foo/bar'], function() {});
+  define.exports('foo/exports', {});
 
+  require('foo/exports');
   require('foo/main');
   require.unsee('foo/bar');
 

--- a/tests/all.js
+++ b/tests/all.js
@@ -1666,3 +1666,9 @@ test('redefining a module when "finalized" should no-op', function(assert) {
   require('foo');
   assert.notOk(second, 'second module definition never used');
 });
+
+test('define.exports', function(assert) {
+  var defaultExport = { example: 'export' };
+  define.exports('foo/bar', defaultExport);
+  assert.equal(require('foo/bar'), defaultExport);
+});


### PR DESCRIPTION
* backfill some readme stuff


Opens the door to (template compiler and ember/glimmer need to learn about this next):

```js
define.exports('my-app/templates/my-template.hbs', { hbs: true, "id": "VVZNWoRm", "block": "{\"statements\":[[1,[26,[\"welcome-page\"]],false],[0,\"\\n\"],[0,\"\\n\"],[1,[26,[\"outlet\"]],false]],\"locals\":[],\"named\":[],\"yields\":[],\"hasPartials\":false}", "meta": { "moduleName": "my-foo-app/templates/application.hbs" }});
```

instead of:

```js
define("my-foo-app/templates/application", ["exports"], function (exports) {
  "use strict";

  Object.defineProperty(exports, "__esModule", {
    value: true
  });

  exports.default = Ember.HTMLBars.template({ "id": "VVZNWoRm", "block": "{\"statements\":[[1,[26,[\"welcome-page\"]],false],[0,\"\\n\"],[0,\"\\n\"],[1,[26,[\"outlet\"]],false]],\"locals\":[],\"named\":[],\"yields\":[],\"hasPartials\":false}", "meta": { "moduleName": "my-foo-app/templates/application.hbs" } });
});
```

benefits:

* no reification step
* no closure
* no juggling pre-parse semantics:

TODO:

- [ ] run tests on a larger code-base to get realistic #'s