### PR TITLE
removed `isArray` fallback

### DIFF
--- a/lib/loader/loader.js
+++ b/lib/loader/loader.js
@@ -74,15 +74,6 @@ var loader, define, requireModule, require, requirejs;
     }
   };
 
-  var _isArray;
-  if (!Array.isArray) {
-    _isArray = function (x) {
-      return Object.prototype.toString.call(x) === '[object Array]';
-    };
-  } else {
-    _isArray = Array.isArray;
-  }
-
   var registry = dict();
   var seen = dict();
 
@@ -232,7 +223,7 @@ var loader, define, requireModule, require, requirejs;
       unsupportedModule(arguments.length);
     }
 
-    if (!_isArray(deps)) {
+    if (!Array.isArray(deps)) {
       callback = deps;
       deps     =  [];
     }


### PR DESCRIPTION
since `Object.create` already being used I think `isArray` can also be dropped
https://github.com/ember-cli/loader.js/blob/master/lib/loader/loader.js#L31