### PR TITLE
Adds option to prevent loader.js modifying export

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,14 @@ loader.wrapModules = function(name, callback) {
     };
 ```
 
+## makeDefaultExport
+
+loader.js creates default exports for ember-cli `amdStrict` mode. If you do not need this behavior you can disable it like so:
+
+```js
+loader.makeDefaultExport = false;
+```
+
 ## Tests
 
 We use [testem](https://github.com/airportyh/testem) for running our test suite.

--- a/lib/loader/loader.js
+++ b/lib/loader/loader.js
@@ -71,7 +71,9 @@ var loader, define, requireModule, require, requirejs;
           }
         }
       }
-    }
+    },
+    // Option to enable or disable the generation of default exports
+    makeDefaultExport: true
   };
 
   var registry = dict();
@@ -138,7 +140,9 @@ var loader, define, requireModule, require, requirejs;
     if (!(this.hasExportsAsDep && result === undefined)) {
       this.module.exports = result;
     }
-    this.makeDefaultExport();
+    if (loader.makeDefaultExport) {
+      this.makeDefaultExport();
+    }
     return this.module.exports;
   };
 

--- a/tests/all.js
+++ b/tests/all.js
@@ -1500,6 +1500,7 @@ test('alias chaining with relative deps works', function() {
 test('wrapModules is called when present', function() {
   var fooCalled = 0;
   var annotatorCalled = 0;
+  var _loaderWrapModules = loader.wrapModules;
   loader.wrapModules = function(id, callback) {
     annotatorCalled++;
     return callback;
@@ -1526,6 +1527,9 @@ test('wrapModules is called when present', function() {
     resolveRelative: 0,
     pendingQueueLength: 1
   });
+
+  // clean up
+  loader.wrapModules = _loaderWrapModules;
 });
 
 test('import require from "require" works', function () {


### PR DESCRIPTION
This PR creates a workaround for https://github.com/ember-cli/loader.js/issues/114

Adding an option to enable(default)/disable `makeDefaultExport`, which mutates the module exports will allow for us to avoid this issue immediately and for maintainers to start a deprecation cycle when ready.

Related to PR: https://github.com/ember-cli/loader.js/pull/128