### PR TITLE
Update "define.alias" API description

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,15 @@ loader.noConflict({
 
 ## Extra stuff
 
-### `define.alias('new-name', 'old/path')`
+### `define.alias('old/path', 'new-name')`
 
 `define.alias` allows creation of a symlink from one module to another, for example:
 
 ```js
-define('foo/bar/baz', [], () => 'hi');
+define('foo', [], () => 'hi');
 define.alias('foo', 'foo/bar/baz');
 
-require('foo') // => 'hi';
+require('foo/bar/baz') // => 'hi';
 require('foo') === require('foo/bar/baz');
 ```
 


### PR DESCRIPTION
The old readme says that the first parameter is the `new name` of `old path`, but according to the [test case](https://github.com/ember-cli/loader.js/blob/d5fb086ceb01296fd17bf32e7241f55501ded8d8/tests/all.js#L1837), the first parameter should be the `old path` and the second one is the `new name`.