### PR TITLE
Fixes problem with loading relative source from bare name dependency

### DIFF
--- a/lib/loader/loader.js
+++ b/lib/loader/loader.js
@@ -306,7 +306,7 @@ var loader, define, requireModule, require, requirejs;
 
     var parts = child.split('/');
     var nameParts = id.split('/');
-    var parentBase = nameParts.slice(0, -1);
+    var parentBase = nameParts.length === 1 ? [nameParts[0]] : nameParts.slice(0, -1);
 
     for (var i = 0, l = parts.length; i < l; i++) {
       var part = parts[i];


### PR DESCRIPTION
Consider the following example.

```js
// index.js
import A from 'bare-dep'

// in bare-dep
import B from './lib/file'
```
This results in `Could not find module lib/file.js imported from bare-dep`. This is because the relative source (var parentBase) is initialized wrong. It should look for bare-dep/lib/file.js instead of lib/file.js.